### PR TITLE
Added checking for pull requests DB migrations conflicts

### DIFF
--- a/config/config_reader.rb
+++ b/config/config_reader.rb
@@ -11,7 +11,7 @@ class Config_reader
 
   def read_repos
     @config['repositories'].each do |repository|
-      @repositories.push(Repository.new(repository['name'], repository['recepients']))
+      @repositories.push(Repository.new(repository['name'], repository['recepients'], repository['migration_folders']))
     end
   end
 

--- a/config/repository.rb
+++ b/config/repository.rb
@@ -1,9 +1,10 @@
 class Repository
 
-  attr_accessor :repository_name, :recipients
+  attr_accessor :repository_name, :recipients, :migration_folders
 
-  def initialize (name, recipients)
+  def initialize (name, recipients, migration_folders)
     @repository_name = name
     @recipients = recipients
+    @migration_folders = migration_folders
   end
 end

--- a/conflict_checker.rb
+++ b/conflict_checker.rb
@@ -145,7 +145,7 @@ class ConflictChecker
     end
     @logger.info('conflict checker end')
   end
-  
+
 
   def check_old_prs_with_migration_conflict(repo, migration_folders)
     still_conflicted = [].to_set
@@ -217,7 +217,7 @@ class ConflictChecker
                        title: "##{pr.pr_id} - #{pr.title}",
                        title_link: "https://github.com/#{repo}/pull/#{pr.pr_id}/",
                        pretext: "Hi #{user}!",
-                       text: "You've got a migrations conflict! Last master migration is #{path}/#{last_master_migration}.",
+                       text: "You've got a database migration conflict! Last master migration is #{path}/#{last_master_migration}.",
                        mrkdwn_in: [
                            "text",
                            "pretext"]

--- a/conflict_checker.rb
+++ b/conflict_checker.rb
@@ -169,10 +169,10 @@ class ConflictChecker
       end
     end
     prs_with_migr_conflict = []
-    last_master_migr_id = last_master_migration.split('__')[0].split('_')[1]
+    last_master_migration_id = last_master_migration[/\d+__/].to_i
     prs_migrations.each do |number, migrations|
-      pr_migr_id = migrations[0].split('__')[0].split('_')[1]
-      if pr_migr_id.to_i - 1 != last_master_migr_id.to_i
+      first_pr_migration_id = migrations[0][/\d+__/].to_i
+      if first_pr_migration_id - 1 != last_master_migration_id
         prs_with_migr_conflict << number
       end
     end
@@ -213,11 +213,11 @@ class ConflictChecker
 
   def create_slack_message_on_migr_conflict(repo, user, pr, path, last_master_migration, recipient)
     attachments = [{
-                       fallback: "Migrations Conflict",
+                       fallback: "DB migration Conflict",
                        title: "##{pr.pr_id} - #{pr.title}",
                        title_link: "https://github.com/#{repo}/pull/#{pr.pr_id}/",
                        pretext: "Hi #{user}!",
-                       text: "You've got a database migration conflict! Last master migration is #{path}/#{last_master_migration}.",
+                       text: "You've got a database migration conflict! Last master migration is: #{path}/#{last_master_migration}.",
                        mrkdwn_in: [
                            "text",
                            "pretext"]

--- a/conflict_checker.rb
+++ b/conflict_checker.rb
@@ -115,7 +115,7 @@ class ConflictChecker
         repo_migrations_folders = repo.migration_folders
         
         check_old_prs_with_migration_conflict(repository, repo_migrations_folders).each do |resolved_pr|
-          @controller.update_pr_migration_conflict(pr, false)
+          @controller.update_pr_migration_conflict(resolved_pr, false)
         end
 
         prs = @controller.get_repo_pr_by_state(repository, 'open')

--- a/conflict_checker.rb
+++ b/conflict_checker.rb
@@ -111,10 +111,73 @@ class ConflictChecker
           @controller.create_or_update_pr pr_data, repository
         end
 
+
+        repo_migrations_folders = repo.migration_folders
+        
+        check_old_prs_with_migration_conflict(repository, repo_migrations_folders).each do |resolved_pr|
+          @controller.update_pr_migration_conflict(pr, false)
+        end
+
+        prs = @controller.get_repo_pr_by_state(repository, 'open')
+        prs_files_for_checking = {}
+        prs.each do |pr|
+          if !pr[:has_migration_conflict]
+            prs_files_for_checking[pr[:pr_id]] = CLIENT.pull_files(repository, pr[:pr_id])
+          end
+        end
+
+        prs_with_migration_conflict = []
+        repo_migrations_folders.each do |path|
+          last_master_migration = @client.get_master_migrations(repository, path)[-1]
+          prs_with_migration_conflict = check_for_migrations_conflicts(last_master_migration, path, prs_files_for_checking)
+
+          prs_with_migration_conflict.each do |pr|
+            pull_request = @controller.get_pr_by_id(pr)[0]
+            user = pull_request[:author]
+            if user
+              recipient = @controller.get_user_by_login(user)[:slack_id]
+              create_slack_message_on_migr_conflict(repository, user, pull_request, path, last_master_migration, recipient)
+            end
+            @controller.update_pr_migration_conflict(pr, true)
+          end
+        end
       end
     end
     @logger.info('conflict checker end')
   end
+  
+
+  def check_old_prs_with_migration_conflict(repo, migration_folders)
+    still_conflicted = [].to_set
+    old_prs_files = {}
+    @controller.get_repo_prs_with_migration_conflict(repo).each do |pr|
+      old_prs_files[pr[:pr_id]] = CLIENT.pull_files(repo, pr[:pr_id])
+    end
+    migration_folders.each do |path|
+      last_master_migration = @client.get_master_migrations(repo, path)[-1]
+      still_conflicted += check_for_migrations_conflicts(last_master_migration, path, old_prs_files)
+    end
+    old_prs_files.keys.to_set - still_conflicted
+  end
+
+  def check_for_migrations_conflicts(last_master_migration, path, prs_files)
+    prs_migrations = {}
+    prs_files.each do |number, pr_files|
+      pr_migrations = @client.get_pr_migrations(pr_files, path)
+      if pr_migrations.length > 0
+        prs_migrations[number] = pr_migrations
+      end
+    end
+    prs_with_migr_conflict = []
+    last_master_migr_id = last_master_migration.split('__')[0].split('_')[1]
+    prs_migrations.each do |number, migrations|
+      pr_migr_id = migrations[0].split('__')[0].split('_')[1]
+      if pr_migr_id.to_i - 1 != last_master_migr_id.to_i
+        prs_with_migr_conflict << number
+      end
+    end
+    prs_with_migr_conflict
+  end 
 
   def check_pull_requests_state (pull_requests, repository)
     pull = []
@@ -146,6 +209,20 @@ class ConflictChecker
       end
     end
     return pull
+  end
+
+  def create_slack_message_on_migr_conflict(repo, user, pr, path, last_master_migration, recipient)
+    attachments = [{
+                       fallback: "Migrations Conflict",
+                       title: "##{pr.pr_id} - #{pr.title}",
+                       title_link: "https://github.com/#{repo}/pull/#{pr.pr_id}/",
+                       pretext: "Hi #{user}!",
+                       text: "You've got a migrations conflict! Last master migration is #{path}/#{last_master_migration}.",
+                       mrkdwn_in: [
+                           "text",
+                           "pretext"]
+                   }]
+    @slack_client.send_message(attachments, recipient)          
   end
 
   def create_slack_message(repo, user, pr_data, recipient)

--- a/database.rb
+++ b/database.rb
@@ -82,6 +82,11 @@ class Database
     pull_request.update(state: state)
   end
 
+  def update_pr_migration_conflict(pr_id, has_migration_conflict)
+    pr = get_pull_request_by_id(pr_id.to_i)
+    pr.update(has_migration_conflict: has_migration_conflict)
+  end
+
 # Getters
   def get_daily_report_state (user_login)
     DailyReport.where(user_name: user_login).first
@@ -101,6 +106,10 @@ class Database
 
   def get_all_repositories
     Repository.all
+  end
+      
+  def get_repo_prs_with_migration_conflict(repo)
+    PullRequest.where(repo: repo, state: 'open', has_migration_conflict: true)
   end
 
   def get_repo_pr_by_mergeable (repo, state)

--- a/db/migrate/20160901062929_add_has_migration_conflict_to_pull_requests.rb
+++ b/db/migrate/20160901062929_add_has_migration_conflict_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddHasMigrationConflictToPullRequests < ActiveRecord::Migration
+  def change
+    add_column :pull_requests, :has_migration_conflict, :boolean, :null => true
+  end
+end

--- a/main_controller.rb
+++ b/main_controller.rb
@@ -110,8 +110,16 @@ class MainController
     @db.get_pull_requests_by_state state
   end
 
+  def get_repo_prs_with_migration_conflict(repo)
+    @db.get_repo_prs_with_migration_conflict(repo)
+  end
+
   def update_pr_state (pr, state)
     @db.update_pull_request_state pr, state
+  end
+
+  def update_pr_migration_conflict(pr_id, has_migration_conflict)
+    @db.update_pr_migration_conflict(pr_id, has_migration_conflict)
   end
 
   def get_recipients_list

--- a/octokit_client.rb
+++ b/octokit_client.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rsuby
 require 'octokit'
+require 'pathname'
 require_relative 'main_controller'
 
 CLIENT = Octokit::Client.new(:access_token => ENV['SEE_THROUGH_TOKEN'])
@@ -110,19 +111,19 @@ class OctokitClient
     result.each do |file|
       result_names << file.to_hash[:name]
     end
-    result_names.sort_by {|m| m.split('__')[0].length}
+    result_names.sort_by {|m| m[/\d+__/].to_i}
   end
 
   def get_pr_migrations(pr_files, path)
     result = []
     pr_files.each do |file|
-      name = file.to_hash[:filename].split('/')
-      file_name, file_path = name.pop, name.join('/')
+      f = Pathname.new(file.to_hash[:filename])
+      file_name, file_path = f.basename.to_s, f.dirname.to_s
       if file_path == path
         result << file_name
       end
     end
-    result.sort_by {|m| m.split('__')[0].length}
+    result.sort_by {|m| m[/\d+__/].to_i}
   end
 
 end

--- a/octokit_client.rb
+++ b/octokit_client.rb
@@ -104,4 +104,25 @@ class OctokitClient
     @main_controller.create_or_update_pr pr_data, repo
   end
 
+  def get_master_migrations(repo, path)
+    result = CLIENT.contents(repo, :path => path)
+    result_names = []
+    result.each do |file|
+      result_names << file.to_hash[:name]
+    end
+    result_names.sort_by {|m| m.split('__')[0].length}
+  end
+
+  def get_pr_migrations(pr_files, path)
+    result = []
+    pr_files.each do |file|
+      name = file.to_hash[:filename].split('/')
+      file_name, file_path = name.pop, name.join('/')
+      if file_path == path
+        result << file_name
+      end
+    end
+    result.sort_by {|m| m.split('__')[0].length}
+  end
+
 end


### PR DESCRIPTION
Added slack notifications on pull request DB migrations version conflict. Checking is done by comparing the latest master migration version, for a given migrations folder, with corresponding pull request version if exists. Conflict has place when pull request has version of the migration that isn't higher. In configuration file _conf.yml_ for each github repository entry added field _migration_folders_, which is a list of dirs where master DB migrations are stored.
