### PR TITLE
Added considering PR labels in activity checker

### DIFF
--- a/config/config_reader.rb
+++ b/config/config_reader.rb
@@ -35,6 +35,7 @@ class Config_reader
     activity_checker_conf = {}
     activity_checker_conf[:timeout] = @config['activity_checker']['timeout']
     activity_checker_conf[:recipients] = @config['activity_checker']['notify']['slack']
+    activity_checker_conf[:labels] = @config['activity_checker']['labels_for_pr_ignoring']
     activity_checker_conf
   end
 

--- a/sample_conf.yml
+++ b/sample_conf.yml
@@ -1,5 +1,7 @@
 activity_checker:
   timeout: 5
+  labels_for_pr_ignoring:
+    - "experiment"
   notify:
     slack:
       - "#debug"


### PR DESCRIPTION
Activity checker consider PR labels. There is a list of labels _labels_for_pr_ignoring_ in _conf.yml_. If PR has some label that is specified in _labels_for_pr_ignoring_, then activity checker ignores that PR.
