### PR TITLE
added new notification rules for activity checker

### DIFF
--- a/activity_checker.rb
+++ b/activity_checker.rb
@@ -85,6 +85,9 @@ class ActivityChecker
         notify = true
       end
     end
+    if notify
+      @controller.update_pr_notified_at(pr[:pr_id], current_time)
+    end
     notify
   end
 

--- a/activity_checker.rb
+++ b/activity_checker.rb
@@ -50,20 +50,42 @@ class ActivityChecker
         else
           days_without_diff_update = TimeDifference.between(db_pr[:diff_updated], current_time).in_days.to_i
           if days_without_diff_update >= @conf[:timeout]
-            @conf[:recipients].each do |receiver|
-              create_slack_notification_on_outdated_pr(repo, db_pr, days_without_diff_update, receiver)
-            end
-            login = db_pr[:author]
-            user = @controller.get_user_by_login(login)
-            if user and user[:enable]
-              recipient = user[:slack_id]
-              create_slack_notification_on_outdated_pr(repo, db_pr, days_without_diff_update, recipient, login)
+                
+            if pr_need_notification?(db_pr, current_time, days_without_diff_update)
+              
+              @conf[:recipients].each do |receiver|
+                create_slack_notification_on_outdated_pr(repo, db_pr, days_without_diff_update, receiver)
+              end
+              login = db_pr[:author]
+              user = @controller.get_user_by_login(login)
+              if user and user[:enable]
+                recipient = user[:slack_id]
+                create_slack_notification_on_outdated_pr(repo, db_pr, days_without_diff_update, recipient, login)
+              end
             end
           end
         end
       end
     end
     @logger.info('activity checker end')
+  end
+
+  def pr_need_notification?(pr, current_time, days_inactive)
+    if !pr[:notified_at]
+      @controller.update_pr_notified_at(pr[:pr_id], current_time)
+      return true
+    end
+    notify = false
+    if days_inactive <= 30
+      if TimeDifference.between(pr[:notified_at], current_time).in_days.to_i >= 3
+        notify = true
+      end
+    elsif days_inactive > 30
+      if TimeDifference.between(pr[:notified_at], current_time).in_days.to_i >= 10
+        notify = true
+      end
+    end
+    notify
   end
 
   def get_pr_diff_sha(repo, pr)  

--- a/activity_checker.rb
+++ b/activity_checker.rb
@@ -52,7 +52,7 @@ class ActivityChecker
           if days_without_diff_update >= @conf[:timeout]
                 
             if pr_need_notification?(db_pr, current_time, days_without_diff_update)
-              
+              @controller.update_pr_notified_at(db_pr[:pr_id], current_time)
               @conf[:recipients].each do |receiver|
                 create_slack_notification_on_outdated_pr(repo, db_pr, days_without_diff_update, receiver)
               end
@@ -72,7 +72,6 @@ class ActivityChecker
 
   def pr_need_notification?(pr, current_time, days_inactive)
     if !pr[:notified_at]
-      @controller.update_pr_notified_at(pr[:pr_id], current_time)
       return true
     end
     notify = false
@@ -84,9 +83,6 @@ class ActivityChecker
       if TimeDifference.between(pr[:notified_at], current_time).in_days.to_i >= 10
         notify = true
       end
-    end
-    if notify
-      @controller.update_pr_notified_at(pr[:pr_id], current_time)
     end
     notify
   end

--- a/database.rb
+++ b/database.rb
@@ -94,6 +94,10 @@ class Database
     })
   end
 
+  def update_pr_notified_at(id, notified_at)
+    PullRequest.where(pr_id: id).first.update(notified_at: notified_at)
+  end
+
 # Getters
   def get_daily_report_state (user_login)
     DailyReport.where(user_name: user_login).first

--- a/db/migrate/20160915104823_add_notified_at_to_pull_requests.rb
+++ b/db/migrate/20160915104823_add_notified_at_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddNotifiedAtToPullRequests < ActiveRecord::Migration
+  def change
+    add_column :pull_requests, :notified_at, :string, :null => true
+  end
+end

--- a/main_controller.rb
+++ b/main_controller.rb
@@ -126,6 +126,10 @@ class MainController
     @db.update_pr_diff_sha(id, diff_sha, diff_updated)
   end
 
+  def update_pr_notified_at(id, notified_at)
+    @db.update_pr_notified_at(id, notified_at)
+  end
+
   def get_recipients_list
     @db.get_recipients
   end


### PR DESCRIPTION
Activity checker computes amount of days PR is inactive and chooses how frequently send notifications if this PR is outdated. 

Rules
- PRs that are inactive for over 30 days are notified once in 10 days.
- PRs that are inactive for less than 30 days are notified once in 3 days.
